### PR TITLE
feat(groups): implement delete_group method (Issue #49)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -229,7 +229,7 @@ This document lists all remaining tasks to complete the Canvus Python API implem
     6. Add docstring following Google format
     7. Add unit test
 
-- [ ] **Task 7.1.4**: Implement delete group method
+- [🔄] **Task 7.1.4**: Implement delete group method - Status: In Progress (Issue #49)
   - **Endpoint**: `DELETE /groups/:id`
   - **Method**: `delete_group(group_id: str) -> None`
   - **Implementation Steps**:

--- a/canvus_api/client.py
+++ b/canvus_api/client.py
@@ -1518,6 +1518,17 @@ class CanvusClient:
         """
         return await self._request("POST", "groups", json_data=payload)
 
+    async def delete_group(self, group_id: str) -> None:
+        """Delete a user group.
+
+        Args:
+            group_id (str): The ID of the group to delete
+
+        Raises:
+            CanvusAPIError: If the request fails or group is not found
+        """
+        await self._request("DELETE", f"groups/{group_id}")
+
     # Workspace Operations
     async def list_workspaces(self, client_id: str) -> List[Workspace]:
         """List all workspaces of a client.

--- a/tests/test_canvas_resources.py
+++ b/tests/test_canvas_resources.py
@@ -488,14 +488,21 @@ async def test_groups_operations(client: CanvusClient) -> None:
             print_success(f"Retrieved group {group_id}: {group}")
 
         # Create a new group (admin only)
+        created_group_id = None
         try:
             new_group = await client.create_group({
                 "name": "Test Group",
                 "description": "A test group created by automated tests"
             })
+            created_group_id = new_group["id"]
             print_success(f"Created new group: {new_group}")
+
+            # Test delete group (admin only)
+            await client.delete_group(created_group_id)
+            print_success(f"Deleted group: {created_group_id}")
+
         except Exception as e:
-            print_warning(f"Could not create group (may not be admin): {e}")
+            print_warning(f"Could not perform admin group operations (may not be admin): {e}")
 
     except Exception as e:
         print_error(f"Groups operations error: {e}")


### PR DESCRIPTION
Implements Task 7.1.4: Implement delete group method

**Changes:**
- Add delete_group method to CanvusClient class
- Method signature: delete_group(group_id: str) -> None
- Uses DELETE /groups/:id endpoint
- Includes proper error handling and Google-style docstring
- Update tests to include delete group functionality
- Follow existing patterns in codebase

**Files Modified:**
- canvus_api/client.py: Added delete_group method
- tests/test_canvas_resources.py: Updated test_groups_operations
- TASKS.md: Updated status to in progress

**Quality Checks:**
- ✅ Code passes syntax check
- ✅ Follows existing patterns
- ✅ Includes proper documentation