### PR TITLE
feat(groups): implement list_group_members method (Issue #56)

### DIFF
--- a/canvus_api/client.py
+++ b/canvus_api/client.py
@@ -1549,6 +1549,20 @@ class CanvusClient:
             "POST", f"groups/{group_id}/members", json_data=payload
         )
 
+    async def list_group_members(self, group_id: str) -> List[Dict[str, Any]]:
+        """List all members of a group.
+
+        Args:
+            group_id (str): The ID of the group to list members for
+
+        Returns:
+            List[Dict[str, Any]]: List of group members as dictionaries
+
+        Raises:
+            CanvusAPIError: If the request fails or group is not found
+        """
+        return await self._request("GET", f"groups/{group_id}/members")
+
     # Workspace Operations
     async def list_workspaces(self, client_id: str) -> List[Workspace]:
         """List all workspaces of a client.

--- a/tests/test_group_operations.py
+++ b/tests/test_group_operations.py
@@ -53,3 +53,58 @@ async def test_add_user_to_group_validation():
     # Test with empty user_id
     with pytest.raises(Exception):
         await client.add_user_to_group("group-123", "")
+
+
+@pytest.mark.asyncio
+async def test_list_group_members_success():
+    """Test successful listing of group members."""
+    client = CanvusClient("https://test.com", "test-token")
+
+    # Mock the _request method
+    mock_response = [
+        {"id": "user-1", "name": "User One", "email": "user1@example.com"},
+        {"id": "user-2", "name": "User Two", "email": "user2@example.com"},
+    ]
+    client._request = AsyncMock(return_value=mock_response)
+
+    # Test the method
+    result = await client.list_group_members("group-123")
+
+    # Verify the result
+    assert result == mock_response
+    assert len(result) == 2
+    assert result[0]["id"] == "user-1"
+    assert result[1]["id"] == "user-2"
+
+    # Verify the request was made correctly
+    client._request.assert_called_once_with("GET", "groups/group-123/members")
+
+
+@pytest.mark.asyncio
+async def test_list_group_members_error():
+    """Test error handling when listing group members fails."""
+    client = CanvusClient("https://test.com", "test-token")
+
+    # Mock the _request method to raise an exception
+    client._request = AsyncMock(side_effect=Exception("API Error"))
+
+    # Test that the exception is propagated
+    with pytest.raises(Exception, match="API Error"):
+        await client.list_group_members("group-123")
+
+
+@pytest.mark.asyncio
+async def test_list_group_members_empty_group():
+    """Test listing members of an empty group."""
+    client = CanvusClient("https://test.com", "test-token")
+
+    # Mock the _request method to return empty list
+    mock_response = []
+    client._request = AsyncMock(return_value=mock_response)
+
+    # Test the method
+    result = await client.list_group_members("group-123")
+
+    # Verify the result
+    assert result == []
+    assert len(result) == 0


### PR DESCRIPTION
Implements Task 7.2.2: List group members method

**Changes:**
- Add  method to CanvusClient
- Method uses GET /groups/:id/members endpoint
- Returns list of group members as dictionaries
- Add comprehensive unit tests for success, error, and empty group scenarios
- Follow existing code patterns and documentation standards

**Testing:**
- All unit tests pass
- Code passes ruff and black checks
- Method follows existing patterns in codebase

Closes #56